### PR TITLE
Revert "entrypoint.sh: export PG* vars"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,13 +11,6 @@ set -e
 
 DB_ARGS=("--db_user" $USER "--db_password" $PASSWORD "--db_host" $HOST "--db_port" $PORT)
 
-# export PG variables to be used by scripts (reset-admin-apssword, saas.py)
-export PGHOST=$HOST
-export PGPORT=$PORT
-export PGUSER=$USER
-export PGPASSWORD=$PASSWORD
-
-
 # generate password if it is not set
 : ${ODOO_MASTER_PASS:=`< /dev/urandom tr -dc A-Za-z0-9 | head -c16;echo;`}
 
@@ -27,6 +20,10 @@ sed -i -e "s/^admin_passwd.*/admin_passwd = $ODOO_MASTER_PASS/" $OPENERP_SERVER
 if [[ "$RESET_ADMIN_PASSWORDS_ON_STARTUP" == "yes" ]]
 then
     NEW_ADMIN_PASSWORD=$ODOO_MASTER_PASS \
+    PGHOST=$HOST \
+    PGPORT=$PORT \
+    PGUSER=$USER \
+    PGPASSWORD=$PASSWORD \
     python /reset-admin-passwords.py
 fi
 


### PR DESCRIPTION
This reverts commit 72e218a8bdf3c737d03fcf63f57422a86eba92a0.

The reason: PG* vars are not passed to docker exec environment