### PR TITLE
[FIX] odoo doesn't work with werkzeug 0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* wkhtmltox.deb && \
     # pip dependencies
     curl --silent https://bootstrap.pypa.io/get-pip.py | python && \
-    pip install werkzeug --upgrade && \
+    pip install "werkzeug<0.12" --upgrade && \
     pip install pillow psycogreen && \
     pip install Boto && \
     pip install FileChunkIO && \


### PR DESCRIPTION
Traceback (most recent call last):
  File "/mnt/odoo-source/odoo/service/server.py", line 720, in run
    self.start()
  File "/mnt/odoo-source/odoo/service/server.py", line 765, in start
    self.server = BaseWSGIServerNoBind(self.multi.app)
  File "/mnt/odoo-source/odoo/service/server.py", line 77, in __init__
    werkzeug.serving.BaseWSGIServer.__init__(self, "1", "1", app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 506, in __init__
    self.port = self.socket.getsockname()[1]
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
  File "/usr/lib/python2.7/socket.py", line 170, in _dummy
    raise error(EBADF, 'Bad file descriptor')
error: [Errno 9] Bad file descriptor