### PR TITLE
[FIX] install-odoo-saas.sh: remove trailing comma in addons_path. It …

### DIFF
--- a/install-odoo-saas.sh
+++ b/install-odoo-saas.sh
@@ -351,7 +351,7 @@
      #  -> pos/
      #  -> ...
      ADDONS_PATH=`ls -d1 $ADDONS_DIR/*/* | tr '\n' ','`
-     ADDONS_PATH=`echo $ODOO_SOURCE_DIR/openerp/addons,$ODOO_SOURCE_DIR/addons,$ADDONS_PATH | sed "s,//,/,g" | sed "s,/,\\\\\/,g" `
+     ADDONS_PATH=`echo $ODOO_SOURCE_DIR/openerp/addons,$ODOO_SOURCE_DIR/addons,$ADDONS_PATH | sed "s,//,/,g" | sed "s,/,\\\\\/,g" | sed "s,.$,,g" `
      sed -ibak "s/addons_path.*/addons_path = $ADDONS_PATH/" $OPENERP_SERVER
 
  fi


### PR DESCRIPTION
…leads to adding `/' into addons_path