### PR TITLE
[FIX] install-odoo-saas.sh: don't change owner of files to `root` whe…

### DIFF
--- a/install-odoo-saas.sh
+++ b/install-odoo-saas.sh
@@ -404,11 +404,11 @@
 
  if [[ "$GIT_PULL" == "yes" ]]
  then
-     git -C $ODOO_SOURCE_DIR pull
+     su --preserve-environment - ${ODOO_USER} -s /bin/bash -c "git -C $ODOO_SOURCE_DIR pull"
 
      for repo in `ls -d1 $ADDONS_DIR/*/*`
      do
-         git -C $repo pull
+         su --preserve-environment - ${ODOO_USER} -s /bin/bash -c "git -C $repo pull"
      done
  fi
 


### PR DESCRIPTION
…n GIT_PULL - all repo files should be owned by $ODOO_USER